### PR TITLE
Changed date in the welcome post so that it becomes the first post on the blog

### DIFF
--- a/src/pages/welcome/index.md
+++ b/src/pages/welcome/index.md
@@ -1,5 +1,5 @@
 ---
 title: Welcome to the Blog
-date: "2017-05-11"
+date: "2017-05-10"
 featuredImage: "featured.png"
 ---


### PR DESCRIPTION
## PROBLEM/FEATURE DESCRIPTION

---

The first post on the blog should be the welcome post. Currently it is either the one on installing pip on OSX or the welcome post as both have the same publish date

## SOLUTION/APPROACH

---

Change the date of the welcome post to be earlier than that of the one on installing pip on OSX