### PR TITLE
Added rule for the index case

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,3 @@
 # Redirect default Netlify subdomain to primary domain
 https://evansdianga.netlify.com/* https://evansdianga.com/:splat 301!
+/* /index.html 200


### PR DESCRIPTION
## PROBLEM/FEATURE DESCRIPTION

---

We need to redirect the user from [https://evansdianga.netlify.com](https://evansdianga.netlify.com) to [https://evansdianga.com](https://evansdianga.com).
Currently the redirect works only from routes that aren't at the root of the site i.e not `index.html` or `/`

## SOLUTION/APPROACH

---

Add a redirect rule for the default/index route case
